### PR TITLE
#16: Add dependencies and workflow dispatch trigger

### DIFF
--- a/.github/workflows/validate_metadata_files.yml
+++ b/.github/workflows/validate_metadata_files.yml
@@ -5,6 +5,7 @@ name: "Validate Metadata"
 on:
   schedule: 
     - cron: 0 0 * * *
+  workflow_dispatch:
 
 jobs:
   validate-metadata:
@@ -17,6 +18,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-      
+
+      - name: install dependencies
+        run: |
+          pip install metomi-isodatetime
+
       - name: validate metadata
         run: python scripts/validate_metadata_conf.py


### PR DESCRIPTION
The script used in the validation workflow requires that metomi isodatetime be installed to the temporary runner within the action workflow file. This was added, as well as a workflow dispatch trigger so that the workflow can be manually triggered outside of the  scheduled time if necessary.