### PR TITLE
#168: add JASMIN request file option

### DIFF
--- a/.github/ISSUE_TEMPLATE/generate_request_file.yml
+++ b/.github/ISSUE_TEMPLATE/generate_request_file.yml
@@ -1,5 +1,9 @@
 # (C) British Crown Copyright 2026, Met Office.
 # Please see LICENSE.md for license details.
+
+# NOTE: This issue template is the required to feed the relavent information to '.github/workflows/generate_request.yml'
+# and 'scripts/generate_request.py'. Changes to this template may result in errors.
+
 name: "Request The Generation Of A CDDS Request File"
 description: Request The Generation Of A CDDS Request File. Please note, i order to generate a request file, workflow metadata form must have been completed and submitted for the appropriate model workflow ID.
 title: "Request The Generation Of A CDDS Request File: <insert model workflow id here>"
@@ -21,10 +25,22 @@ body:
       required: true
 
   - type: dropdown
+    id: request_type
+    attributes:
+      label: Request Type
+      description: The type of request to generate. Unless using JASMIN, please select the default "Standard Met Office Request".
+      options:
+        - Standard Met Office Request
+        - JASMIN Request
+      default: 0
+    validations:
+      required: true
+
+  - type: dropdown
     id: streams
     attributes:
       label: Streams
-      description: The streams you wish to process with.
+      description: The stream(s) you wish to process with.
       multiple: true
       options:
         - ap4
@@ -39,6 +55,8 @@ body:
         - onm 
         - ind
         - ond
+    validations:
+      required: true
 
   - type: input 
     id: package

--- a/.github/workflows/generate_request.yml
+++ b/.github/workflows/generate_request.yml
@@ -1,6 +1,9 @@
 # (C) British Crown Copyright 2026, Met Office.
 # Please see LICENSE.md for license details.
 
+# NOTE: This workflow is triggered only when issues labeled "request_file_request" are opened/editted and relies on the
+# inputs given by '.github/ISSUE_TEMPLATE/generate_request_file.yml'
+
 name: "Generate a request file"
 on: 
   issues:
@@ -61,6 +64,7 @@ jobs:
           git push origin main
 
           gh issue comment "$NUMBER" --body "$BODY"
+          gh issue close --repo "$REPO" "$ISSUE"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/generate_request.yml
+++ b/.github/workflows/generate_request.yml
@@ -1,7 +1,7 @@
 # (C) British Crown Copyright 2026, Met Office.
 # Please see LICENSE.md for license details.
 
-# NOTE: This workflow is triggered only when issues labeled "request_file_request" are opened/editted and relies on the
+# NOTE: This workflow is triggered only when issues labelled "request_file_request" are opened/editted and relies on the
 # inputs given by '.github/ISSUE_TEMPLATE/generate_request_file.yml'
 
 name: "Generate a request file"

--- a/scripts/generate_request.py
+++ b/scripts/generate_request.py
@@ -3,6 +3,9 @@
 """A script to generate a functional request file using information provided from a given workflow metadata
 configuration file.
 
+NOTE: This script relies on inputs given from '.github/ISSUE_TEMPLATE/generate_request_file.yml' and is utilised by the
+'.github/workflows/generate_request.yml' workflow automatically upon issue submission.
+
 """
 import os
 import re
@@ -210,7 +213,7 @@ def validate_request(request: dict) -> None:
         raise RuntimeError(f"Unable to valdidate request file against cvs:\n{cv_errors}")
 
 
-def write_request(data: SectionProxy, request: dict) -> str:
+def write_request(filename_prefix, data: SectionProxy, request: dict) -> str:
     """Writes out the fully populated REQUEST TEMPLATE dictionary to a configuration file format.
 
     Parameters
@@ -225,7 +228,7 @@ def write_request(data: SectionProxy, request: dict) -> str:
     str
         The request filename.
     """
-    filename = f"request_{data['model_workflow_id']}_{request['common']['package']}.cfg"
+    filename = f"{filename_prefix}_request_{data['model_workflow_id']}_{request['common']['package']}.cfg"
     with open(Path("requests") / filename, "w") as f:
         for section_header, content in request.items():
             f.write(f"[{section_header}]\n")
@@ -242,6 +245,22 @@ def generate_request_config() -> None:
     issue_info = process_issue_form()
     request = REQUEST_TEMPLATE
 
+    # If the user needs a JASMIN request, an additional field is needed to identify their JASMIN account (to be updated
+    # locally by the user once the request has been downloaded).
+    if issue_info["request_type"] == "JASMIN Request":
+        request["conversion"].update({"jasmin_account": ""})
+        filename_prefix = "jasmin"  # Required to help immedietly identify JASMIN based requests
+    elif issue_info["request_type"] == "Standard Met Office Request":
+        filename_prefix = "mo"  # Required to help immedietly identify Met Office based requests
+    else:
+        err_msg = (f"Unrecognised request type: '{issue_info["request_type"]}'. Expected 'JASMIN Request' or "
+                   "'Standard Met Office Request'")
+        with open(os.environ["GITHUB_OUTPUT"], "a") as gh:
+            gh.write(f"err_msg={err_msg}")
+            sys.exit(1)
+
+    # Identify the workflow metadata config file associated with the workflow ID given in the issue. This file must
+    # exist to proceed.
     cfg_file = f"{WORKFLOW_METADATA_DIR}/{issue_info['model_workflow_id']}.cfg"
     if not os.path.exists(cfg_file):
         err_msg = (f"The given model workflow ID {issue_info['model_workflow_id']} does not have an associated "
@@ -252,9 +271,12 @@ def generate_request_config() -> None:
     config = ConfigParser()
     config.read(cfg_file)
 
+    # Populate the request template with values from the workflow metadata config file and re validate where possible.
     update_request(request, config, issue_info)
     validate_request(request)
-    filename = write_request(config["data"], request)
+    filename = write_request(filename_prefix, config["data"], request)
+
+    # Note the relative path to the generated request and assocaited variable list to help with user navigation.
     with open(os.environ["GITHUB_OUTPUT"], "a") as gh:
         gh.write(f"var_list={request['data']['variable_list_file']}\n")
         gh.write(f"request_filename={filename}")


### PR DESCRIPTION
Closes issue #168 

As part of this view please see an example of the generated jasmin request on the testing fork [requests/jasmin_request_u-dv341_testjasmin.cfg](https://github.com/mo-laurenboon/simulation-metadata-TESTING-ONLY/blob/main/requests/jasmin_request_u-dv341_testjasmin.cfg) to confirm that all jasmin related required fields are present and that the request appears as expected. 

Changes
----------
- Allows the user to generate a jasmin request by adding the field "jasmin_account" to the conversion section (to be populated locally by the user once the request has been downloaded). 
- Updates the request filename convention with a prefix ("jasmin_" or "mo_") to allow us to immediately identify a JASMIN request vs a standard Met Office request during support situations.
- Introduces additional comments to the head of the issue template, workflow file and python script to increase the transparency of their connection and warn any future developers that changes to one of these files may affect the utility of others.
- Introduces additional inline comments to improve code clarity